### PR TITLE
Fix caching, concurrency & validation bugs; modernize to RestClient

### DIFF
--- a/src/main/java/com/spro93/smarthome/SmarthomeApplication.java
+++ b/src/main/java/com/spro93/smarthome/SmarthomeApplication.java
@@ -2,9 +2,9 @@ package com.spro93.smarthome;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.web.client.RestTemplate;
+
+import java.time.Clock;
 
 @SpringBootApplication
 public class SmarthomeApplication {
@@ -14,8 +14,8 @@ public class SmarthomeApplication {
 	}
 
 	@Bean
-	public RestTemplate restTemplate(RestTemplateBuilder builder) {
-		return builder.build();
+	public Clock clock() {
+		return Clock.systemDefaultZone();
 	}
 
 }

--- a/src/main/java/com/spro93/smarthome/service/ElectricityService.java
+++ b/src/main/java/com/spro93/smarthome/service/ElectricityService.java
@@ -1,33 +1,54 @@
 package com.spro93.smarthome.service;
 
 import com.spro93.smarthome.model.ElectricityPrice;
-import lombok.RequiredArgsConstructor;
+import com.spro93.smarthome.model.PriceData;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.Comparator;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class ElectricityService {
 
     private static final String API_URL = "https://apis.smartenergy.at/market/v1/price";
-    private ElectricityPrice cachedPrice;
-    private ZonedDateTime cacheDate;
+    private static final Duration MAX_CACHE_AGE = Duration.ofHours(24);
+    private static final int DEFAULT_INTERVAL_MINUTES = 15;
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
+    private final Clock clock;
+
+    /**
+     * Immutable view of the cached prices together with the instant they stop being usable.
+     * Holding both values in a single object lets us publish them atomically through one
+     * {@code volatile} reference instead of juggling two independently-written fields.
+     */
+    private record CachedPrices(ElectricityPrice price, ZonedDateTime validUntil) {
+        boolean isUsableAt(final ZonedDateTime now) {
+            return now.isBefore(validUntil);
+        }
+    }
+
+    private volatile CachedPrices cache;
+
+    public ElectricityService(final RestClient.Builder restClientBuilder, final Clock clock) {
+        this.restClient = restClientBuilder.build();
+        this.clock = clock;
+    }
 
     public String isPriceNegative(final Double additionalAmount) {
-        var now = ZonedDateTime.now();
-        var prices = getElectricityPrices();
+        var now = ZonedDateTime.now(clock);
+        var prices = getElectricityPrices(now);
+        var windowMillis = intervalMinutes(prices) * 60_000L;
 
         return prices.data().stream()
                 .filter(element -> {
                     var diff = Duration.between(element.date(), now).toMillis();
-                    return diff > 0 && diff <= 15 * 60 * 1000;
+                    return diff > 0 && diff <= windowMillis;
                 })
                 .findFirst()
                 .map(priceData -> {
@@ -47,44 +68,63 @@ public class ElectricityService {
                 });
     }
 
-    private ElectricityPrice getElectricityPrices() {
-        if (isPricesValid()) {
+    private ElectricityPrice getElectricityPrices(final ZonedDateTime now) {
+        var current = cache;
+        if (current != null && current.isUsableAt(now)) {
             log.info("Returning from cache");
-            return cachedPrice;
+            return current.price();
         }
-        return fetchElectricityPrices();
+
+        synchronized (this) {
+            // Re-check inside the lock: another thread may have refreshed while we waited.
+            current = cache;
+            if (current != null && current.isUsableAt(now)) {
+                log.info("Returning from cache");
+                return current.price();
+            }
+            try {
+                var refreshed = fetchElectricityPrices(now);
+                cache = refreshed;
+                return refreshed.price();
+            } catch (RuntimeException ex) {
+                if (current != null) {
+                    log.warn("Failed to refresh electricity prices, serving last known data. Cause: {}", ex.getMessage());
+                    return current.price();
+                }
+                throw ex;
+            }
+        }
     }
 
-    private boolean isPricesValid() {
-        if (cachedPrice == null || cachedPrice.data().isEmpty()) {
-            log.info("Cache empty");
-            return false;
-        }
-
-        var now = ZonedDateTime.now();
-        var diff = Duration.between(cacheDate, now);
-
-        if (diff.toMillis() >= 24 * 60 * 60 * 1000) {
-            log.info("Cache is outdated");
-            return false;
-        } else if (cachedPrice.data().getFirst().date().isBefore(now)) {
-            log.info("Cache's values are invalid");
-            return false;
-        } else {
-            return true;
-        }
-    }
-
-    private ElectricityPrice fetchElectricityPrices() {
+    private CachedPrices fetchElectricityPrices(final ZonedDateTime now) {
         log.info("Fetching new prices");
-        var price = restTemplate.getForObject(API_URL, ElectricityPrice.class);
-        this.cachedPrice = price;
-        this.cacheDate = ZonedDateTime.now();
-        return price;
+        var price = restClient.get()
+                .uri(API_URL)
+                .retrieve()
+                .body(ElectricityPrice.class);
+
+        if (price == null || price.data().isEmpty()) {
+            throw new IllegalStateException("Electricity price API returned no usable data");
+        }
+
+        // The cache stays valid until the data no longer covers the current time (independent of
+        // the order in which the API returns the slots), bounded by a hard maximum age.
+        var coverageEnd = price.data().stream()
+                .map(PriceData::date)
+                .max(Comparator.naturalOrder())
+                .orElse(now)
+                .plusMinutes(intervalMinutes(price));
+        var ttlCap = now.plus(MAX_CACHE_AGE);
+        var validUntil = coverageEnd.isBefore(ttlCap) ? coverageEnd : ttlCap;
+
+        return new CachedPrices(price, validUntil);
+    }
+
+    private int intervalMinutes(final ElectricityPrice price) {
+        return price.interval() > 0 ? price.interval() : DEFAULT_INTERVAL_MINUTES;
     }
 
     private String formatResponse(final boolean resp) {
         return resp ? "1" : "0";
     }
 }
-

--- a/src/main/java/com/spro93/smarthome/service/SunPositionService.java
+++ b/src/main/java/com/spro93/smarthome/service/SunPositionService.java
@@ -22,16 +22,16 @@ public class SunPositionService {
         var latitude = getValidValue(query.get("latitude"), -90, 90, LATITUDE_FALLBACK);
         var longitude = getValidValue(query.get("longitude"), -180, 180, LONGITUDE_FALLBACK);
 
-        var minAltitude = query.containsKey("minAltitude") ? Double.parseDouble(query.get("minAltitude")) : MIN_ALTITUDE_DEFAULT;
-        var maxAltitude = query.containsKey("maxAltitude") ? Double.parseDouble(query.get("maxAltitude")) : MAX_ALTITUDE_DEFAULT;
+        var minAltitude = parseOrDefault(query.get("minAltitude"), MIN_ALTITUDE_DEFAULT);
+        var maxAltitude = parseOrDefault(query.get("maxAltitude"), MAX_ALTITUDE_DEFAULT);
 
         var correctDeclination = !query.containsKey("correctDeclination") || Boolean.parseBoolean(query.get("correctDeclination"));
 
         var minAzimuthRaw = Double.parseDouble(query.get("minAzimuth"));
         var maxAzimuthRaw = Double.parseDouble(query.get("maxAzimuth"));
 
-        var minAzimuth = correctDeclination ? correctAngle(minAzimuthRaw, latitude, longitude) : minAzimuthRaw;
-        var maxAzimuth = correctDeclination ? correctAngle(maxAzimuthRaw, latitude, longitude) : maxAzimuthRaw;
+        var minAzimuth = normalizeAzimuth(correctDeclination ? correctAngle(minAzimuthRaw, latitude, longitude) : minAzimuthRaw);
+        var maxAzimuth = normalizeAzimuth(correctDeclination ? correctAngle(maxAzimuthRaw, latitude, longitude) : maxAzimuthRaw);
 
         log.info("Using {\"latitude\":{},\"longitude\":{},\"minAzimuth\":{},\"maxAzimuth\":{},\"minAltitude\":{},\"maxAltitude\":{}} for calculation",
                 latitude, longitude, minAzimuth, maxAzimuth, minAltitude, maxAltitude);
@@ -62,12 +62,45 @@ public class SunPositionService {
         return fallback;
     }
 
-    private boolean isAngleInRange(final double value, final double min, final double max) {
+    /**
+     * Parses an optional numeric parameter, falling back to {@code fallback} when it is absent,
+     * blank or not a number. This keeps a present-but-empty query parameter (e.g. {@code ?minAltitude=})
+     * from blowing up with a {@link NumberFormatException}.
+     */
+    private double parseOrDefault(final String value, final double fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException _) {
+            return fallback;
+        }
+    }
+
+    /**
+     * Checks whether {@code value} (an angle in {@code [0, 360)}) falls inside the inclusive range.
+     * When {@code min > max} the range is treated as wrapping around the 0/360 boundary.
+     */
+    static boolean isAngleInRange(final double value, final double min, final double max) {
         if (min <= max) {
             return value >= min && value <= max;
         } else {
             return value >= min || value <= max;
         }
+    }
+
+    /**
+     * Maps an arbitrary azimuth onto {@code [0, 360]} so that the declination correction cannot push
+     * a bound outside the range produced by {@link SunPosition#getAzimuth()}. Values that are already
+     * canonical (including an explicit {@code 360}) are left untouched.
+     */
+    static double normalizeAzimuth(final double azimuth) {
+        if (azimuth >= 0 && azimuth <= 360) {
+            return azimuth;
+        }
+        var wrapped = azimuth % 360;
+        return wrapped < 0 ? wrapped + 360 : wrapped;
     }
 
     private double correctAngle(final double value, final double latitude, final double longitude) {

--- a/src/main/java/com/spro93/smarthome/util/GeoMag.java
+++ b/src/main/java/com/spro93/smarthome/util/GeoMag.java
@@ -1,6 +1,9 @@
 package com.spro93.smarthome.util;
 
-public class GeoMag {
+public final class GeoMag {
+
+    private GeoMag() {
+    }
 
     private static final double[][] gnmWmm2020 = {
             {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 server.port=3000
+
+# Prevent a slow or unresponsive upstream API from blocking request threads indefinitely.
+spring.http.client.connect-timeout=5s
+spring.http.client.read-timeout=10s

--- a/src/test/java/com/spro93/smarthome/SmarthomeApplicationTests.java
+++ b/src/test/java/com/spro93/smarthome/SmarthomeApplicationTests.java
@@ -37,4 +37,15 @@ public class SmarthomeApplicationTests {
 		mockMvc.perform(get("/api/isExposedToSun"))
 				.andExpect(status().isBadRequest());
 	}
+
+	@Test
+	public void testIsExposedToSunEmptyOptionalAltitudeReturnsOk() throws Exception {
+		// A present-but-empty optional parameter must default rather than cause an HTTP 500.
+		mockMvc.perform(get("/api/isExposedToSun")
+						.param("minAzimuth", "90")
+						.param("maxAzimuth", "270")
+						.param("minAltitude", "")
+						.param("correctDeclination", "false"))
+				.andExpect(status().isOk());
+	}
 }

--- a/src/test/java/com/spro93/smarthome/controller/ElectricityControllerTest.java
+++ b/src/test/java/com/spro93/smarthome/controller/ElectricityControllerTest.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.client.RestTemplate;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -21,10 +20,6 @@ class ElectricityControllerTest {
 
     @MockitoBean
     private ElectricityService electricityService;
-
-    @MockitoBean
-    @SuppressWarnings("unused")
-    private RestTemplate restTemplate;
 
     @Test
     void getElectricityPrice_noParam_returnsOk() throws Exception {

--- a/src/test/java/com/spro93/smarthome/controller/SunPositionControllerTest.java
+++ b/src/test/java/com/spro93/smarthome/controller/SunPositionControllerTest.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.client.RestTemplate;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -22,10 +21,6 @@ class SunPositionControllerTest {
 
     @MockitoBean
     private SunPositionService sunPositionService;
-
-    @MockitoBean
-    @SuppressWarnings("unused")
-    private RestTemplate restTemplate;
 
     @Test
     void isExposedToSun_validMinimalParams_returnsOk() throws Exception {

--- a/src/test/java/com/spro93/smarthome/service/ElectricityServiceTest.java
+++ b/src/test/java/com/spro93/smarthome/service/ElectricityServiceTest.java
@@ -1,98 +1,209 @@
 package com.spro93.smarthome.service;
 
-import com.spro93.smarthome.model.ElectricityPrice;
-import com.spro93.smarthome.model.PriceData;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
 
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.List;
+import java.time.format.DateTimeFormatter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-@ExtendWith(MockitoExtension.class)
 class ElectricityServiceTest {
 
-    @Mock
-    private RestTemplate restTemplate;
+    private static final String API_URL = "https://apis.smartenergy.at/market/v1/price";
 
-    @InjectMocks
+    private MutableClock clock;
+    private MockRestServiceServer server;
     private ElectricityService electricityService;
 
-    /**
-     * Creates a price list with:
-     * - a future entry (so the cache validity check passes on the second call)
-     * - a "current" entry dated 5 minutes ago (within the 15-minute matching window)
-     */
-    private ElectricityPrice createPrices(double currentValue) {
-        var future = new PriceData(ZonedDateTime.now().plusHours(1), 0.0);
-        var current = new PriceData(ZonedDateTime.now().minusMinutes(5), currentValue);
-        return new ElectricityPrice("tariff", "ct/kWh", 15, List.of(future, current));
-    }
-
-    private ElectricityPrice createPricesOutsideWindow() {
-        var future = new PriceData(ZonedDateTime.now().plusHours(1), 0.0);
-        var old = new PriceData(ZonedDateTime.now().minusMinutes(20), -10.0);
-        return new ElectricityPrice("tariff", "ct/kWh", 15, List.of(future, old));
+    @BeforeEach
+    void setUp() {
+        clock = new MutableClock(Instant.parse("2026-05-29T10:00:00Z"), ZoneOffset.UTC);
+        var builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        electricityService = new ElectricityService(builder, clock);
     }
 
     @Test
     void isPriceNegative_negativePriceNoAdditional_returnsOne() {
-        when(restTemplate.getForObject(any(String.class), eq(ElectricityPrice.class)))
-                .thenReturn(createPrices(-10.0));
+        expectFetch(priceJson(now(), -10.0, false));
 
         assertEquals("1", electricityService.isPriceNegative(null));
+        server.verify();
     }
 
     @Test
     void isPriceNegative_positivePriceNoAdditional_returnsZero() {
-        when(restTemplate.getForObject(any(String.class), eq(ElectricityPrice.class)))
-                .thenReturn(createPrices(10.0));
+        expectFetch(priceJson(now(), 10.0, false));
 
         assertEquals("0", electricityService.isPriceNegative(null));
-    }
-
-    @Test
-    void isPriceNegative_noPriceInCurrentWindow_returnsZero() {
-        when(restTemplate.getForObject(any(String.class), eq(ElectricityPrice.class)))
-                .thenReturn(createPricesOutsideWindow());
-
-        assertEquals("0", electricityService.isPriceNegative(null));
+        server.verify();
     }
 
     @Test
     void isPriceNegative_additionalAmountMakesPriceNegative_returnsOne() {
-        when(restTemplate.getForObject(any(String.class), eq(ElectricityPrice.class)))
-                .thenReturn(createPrices(5.0));
+        expectFetch(priceJson(now(), 5.0, false));
 
         assertEquals("1", electricityService.isPriceNegative(-10.0));
+        server.verify();
     }
 
     @Test
     void isPriceNegative_additionalAmountKeepsPricePositive_returnsZero() {
-        when(restTemplate.getForObject(any(String.class), eq(ElectricityPrice.class)))
-                .thenReturn(createPrices(-5.0));
+        expectFetch(priceJson(now(), -5.0, false));
 
         assertEquals("0", electricityService.isPriceNegative(10.0));
+        server.verify();
+    }
+
+    @Test
+    void isPriceNegative_noPriceInCurrentWindow_returnsZero() {
+        // The only past slot is 20 minutes old (outside the 15-minute window).
+        var json = """
+                {"tariff":"EPEX","unit":"ct/kWh","interval":15,"data":[
+                  {"date":"%s","value":-10.0},
+                  {"date":"%s","value":0.0}
+                ]}""".formatted(iso(now().minusMinutes(20)), iso(now().plusHours(1)));
+        expectFetch(json);
+
+        assertEquals("0", electricityService.isPriceNegative(null));
+        server.verify();
     }
 
     @Test
     void isPriceNegative_cacheValid_doesNotFetchAgain() {
-        when(restTemplate.getForObject(any(String.class), eq(ElectricityPrice.class)))
-                .thenReturn(createPrices(-10.0));
+        expectFetch(priceJson(now(), -10.0, false));
 
         electricityService.isPriceNegative(null);
         electricityService.isPriceNegative(null);
 
-        verify(restTemplate, times(1)).getForObject(any(String.class), eq(ElectricityPrice.class));
+        // A single expectation: a second HTTP call would be reported as unexpected.
+        server.verify();
+    }
+
+    @Test
+    void isPriceNegative_chronologicallyOrderedData_cacheStaysValid() {
+        // The real API returns the current slot first. The previous cache logic invalidated the
+        // cache immediately for this ordering; a single expectation proves the fix.
+        expectFetch(priceJson(now(), -10.0, true));
+
+        electricityService.isPriceNegative(null);
+        electricityService.isPriceNegative(null);
+
+        server.verify();
+    }
+
+    @Test
+    void isPriceNegative_cacheExpired_refetches() {
+        var start = now();
+        expectFetch(priceJson(start, -10.0, false));
+        expectFetch(priceJson(start.plusHours(2), 5.0, false));
+
+        assertEquals("1", electricityService.isPriceNegative(null));
+        clock.advance(Duration.ofHours(2)); // past the cached data's coverage
+        assertEquals("0", electricityService.isPriceNegative(null));
+
+        server.verify();
+    }
+
+    @Test
+    void isPriceNegative_upstreamFailsWithStaleCache_servesStaleInsteadOfThrowing() {
+        expectFetch(priceJson(now(), -10.0, false));
+        server.expect(once(), requestTo(API_URL)).andRespond(withServerError());
+
+        assertEquals("1", electricityService.isPriceNegative(null));
+        clock.advance(Duration.ofHours(2)); // expire the cache so the next call refetches
+
+        // The refresh fails, so the last known data is served. It no longer covers "now",
+        // hence "0" — but crucially the call does not propagate the upstream error.
+        assertEquals("0", electricityService.isPriceNegative(null));
+        server.verify();
+    }
+
+    @Test
+    void isPriceNegative_upstreamFailsWithNoCache_propagates() {
+        server.expect(once(), requestTo(API_URL)).andRespond(withServerError());
+
+        assertThrows(RuntimeException.class, () -> electricityService.isPriceNegative(null));
+        server.verify();
+    }
+
+    @Test
+    void isPriceNegative_emptyDataWithNoCache_throws() {
+        expectFetch("""
+                {"tariff":"EPEX","unit":"ct/kWh","interval":15,"data":[]}""");
+
+        assertThrows(IllegalStateException.class, () -> electricityService.isPriceNegative(null));
+        server.verify();
+    }
+
+    // --- helpers ---
+
+    private ZonedDateTime now() {
+        return ZonedDateTime.now(clock);
+    }
+
+    private static String iso(final ZonedDateTime time) {
+        return time.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
+    /**
+     * Builds an API response with a "current" slot five minutes before {@code reference} and a
+     * future slot one hour later. {@code currentFirst} controls whether the current slot is listed
+     * before the future one, so both API orderings can be exercised.
+     */
+    private static String priceJson(final ZonedDateTime reference, final double currentValue, final boolean currentFirst) {
+        var current = "{\"date\":\"%s\",\"value\":%s}".formatted(iso(reference.minusMinutes(5)), currentValue);
+        var future = "{\"date\":\"%s\",\"value\":0.0}".formatted(iso(reference.plusHours(1)));
+        var data = currentFirst ? current + "," + future : future + "," + current;
+        return "{\"tariff\":\"EPEX\",\"unit\":\"ct/kWh\",\"interval\":15,\"data\":[%s]}".formatted(data);
+    }
+
+    private void expectFetch(final String body) {
+        server.expect(once(), requestTo(API_URL))
+                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+    }
+
+    /** A {@link Clock} whose instant can be advanced, so cache expiry can be tested deterministically. */
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+        private final ZoneId zone;
+
+        MutableClock(final Instant instant, final ZoneId zone) {
+            this.instant = instant;
+            this.zone = zone;
+        }
+
+        void advance(final Duration amount) {
+            this.instant = this.instant.plus(amount);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return zone;
+        }
+
+        @Override
+        public Clock withZone(final ZoneId zone) {
+            return new MutableClock(instant, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
     }
 }

--- a/src/test/java/com/spro93/smarthome/service/SunPositionServiceTest.java
+++ b/src/test/java/com/spro93/smarthome/service/SunPositionServiceTest.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SunPositionServiceTest {
@@ -126,5 +127,53 @@ class SunPositionServiceTest {
 
         var result = sunPositionService.isExposed(query);
         assertTrue(result.equals("0") || result.equals("1"), "Response must be '0' or '1'");
+    }
+
+    @Test
+    void isExposed_emptyOptionalAltitude_usesDefaultsInsteadOfFailing() {
+        // A present-but-empty optional parameter (?minAltitude=) must not trigger a 500.
+        var query = new HashMap<String, String>();
+        query.put("minAzimuth", "0");
+        query.put("maxAzimuth", "360");
+        query.put("minAltitude", "");
+        query.put("maxAltitude", "");
+        query.put("correctDeclination", "false");
+
+        var result = sunPositionService.isExposed(query);
+        assertTrue(result.equals("0") || result.equals("1"), "Response must be '0' or '1'");
+    }
+
+    @Test
+    void normalizeAzimuth_keepsCanonicalValues() {
+        assertEquals(0.0, SunPositionService.normalizeAzimuth(0), 1e-9);
+        assertEquals(180.0, SunPositionService.normalizeAzimuth(180), 1e-9);
+        // Exactly 360 is preserved so a [0, 360] full-circle request is not collapsed to a point.
+        assertEquals(360.0, SunPositionService.normalizeAzimuth(360), 1e-9);
+    }
+
+    @Test
+    void normalizeAzimuth_wrapsOutOfRangeValues() {
+        assertEquals(10.0, SunPositionService.normalizeAzimuth(370), 1e-9);
+        assertEquals(355.0, SunPositionService.normalizeAzimuth(-5), 1e-9);
+        assertEquals(5.0, SunPositionService.normalizeAzimuth(725), 1e-9);
+        assertEquals(355.0, SunPositionService.normalizeAzimuth(-365), 1e-9);
+    }
+
+    @Test
+    void isAngleInRange_nonWrappingRange() {
+        assertTrue(SunPositionService.isAngleInRange(15, 10, 20));
+        assertTrue(SunPositionService.isAngleInRange(10, 10, 20));
+        assertTrue(SunPositionService.isAngleInRange(20, 10, 20));
+        assertFalse(SunPositionService.isAngleInRange(25, 10, 20));
+        assertFalse(SunPositionService.isAngleInRange(5, 10, 20));
+    }
+
+    @Test
+    void isAngleInRange_wrappingRange() {
+        // min > max means the range wraps across the 0/360 boundary.
+        assertTrue(SunPositionService.isAngleInRange(355, 350, 20));
+        assertTrue(SunPositionService.isAngleInRange(10, 350, 20));
+        assertFalse(SunPositionService.isAngleInRange(100, 350, 20));
+        assertFalse(SunPositionService.isAngleInRange(200, 350, 20));
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes several bugs and design issues found while reviewing the codebase, and modernizes the HTTP integration to the current Spring stack. All work was verified by compiling and running the full test suite on **JDK 25 / Spring Boot 4.0.6**, and by booting the packaged app and exercising every endpoint (including a live call to the smartenergy.at API).

## Bug fixes

- **Price cache was effectively dead in production.** `ElectricityService` decided cache validity from `data().getFirst().date().isBefore(now)`. The real API returns price slots in chronological order, so the first slot moves into the past almost immediately — every request re-fetched, defeating the cache (the old test only passed because it reversed the slot ordering). Validity is now derived from the data's actual coverage window, **independent of element ordering**, bounded by a hard maximum age.
- **Cache was not thread-safe.** Two mutable fields (`cachedPrice`, `cacheDate`) were written without synchronization on a singleton serving concurrent requests. They are replaced by a single immutable snapshot published through one `volatile` reference and read via double-checked locking.
- **Unhandled upstream failures.** A `null`/empty response body could NPE, and any upstream error surfaced as a raw 500. The service now validates the body and, on a failed refresh, **falls back to the last known data** instead of failing the request.
- **HTTP 500 on an empty optional parameter.** `?minAltitude=` passed the controller's validation (empty allowed) but then hit `Double.parseDouble("")` in `SunPositionService`. Empty/blank optional altitudes now fall back to their defaults.
- **Azimuth bounds not normalized after declination correction.** Adding the magnetic declination could push a bound outside `[0,360)`, making the range check wrong near the 0/360 boundary. Bounds are now normalized (an explicit `360` is preserved so a full-circle request isn't collapsed).

## Design / modernization

- **`RestTemplate` → `RestClient`.** The `spring-boot-starter-restclient` dependency was already declared; `RestTemplate` is in maintenance mode. The client is built from the auto-configured `RestClient.Builder`.
- **Connect/read timeouts** configured via `spring.http.client.*` so a slow upstream cannot block request threads indefinitely.
- **Injected `Clock`** into `ElectricityService` for deterministic, testable time handling.
- **`GeoMag`** is now a `final`, non-instantiable utility class.

## Tests

Test count increased from **35 → 46**, all green.

- `ElectricityServiceTest` rewritten around `MockRestServiceServer` + `RestClient` (now exercises **real JSON deserialization** of the API response) with a controllable `Clock`. New coverage: cache hit avoids refetch, **cache stays valid for chronologically-ordered data** (directly pins the main bug fix), cache expiry triggers refetch, stale-on-error fallback, and empty/error responses.
- New unit tests for azimuth normalization and angle-range wrap-around.
- New unit + end-to-end tests for the empty-altitude fix.

## Verification

```
mvn test      → Tests run: 46, Failures: 0, Errors: 0
mvn package   → BUILD SUCCESS (repackaged boot jar)
```

Booted the jar and confirmed: invalid params → 400, missing required params → 400, `?minAltitude=` → **200** (previously 500), sun query → 200, and the live `/api/electricityPrice` → 200 (real API call deserialized correctly through `RestClient`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
