### PR TITLE
Make server port configurable via Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,4 @@ RUN addgroup -S spring && adduser -S spring -G spring
 USER spring
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
-EXPOSE 3000
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ To pull the Docker image from Docker Hub use this command:
 
 Once the server is running it is reachable on your host with port 3000 by default. Also if the host system crashes or reboots, the container is started automatically again.
 
+### Configuration
+
+The port on which the server is reachable can be configured using the `PORT` environment variable when using Docker Compose.
+
+To run the server on a different port (e.g., 8080):
+
+```bash
+PORT=8080 docker compose up -d
+```
+
+If no `PORT` is specified, it defaults to `3000`.
+
 ## Endpoints
 
 ### Check if electricity price is negative

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,7 @@ services:
     hostname: smarthome
     build: ./
     restart: always
+    environment:
+      - SERVER_PORT=${PORT:-3000}
     ports:
-      - 3000:3000
+      - ${PORT:-3000}:${PORT:-3000}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-server.port=3000
+server.port=${SERVER_PORT:3000}
 
 # Prevent a slow or unresponsive upstream API from blocking request threads indefinitely.
 spring.http.client.connect-timeout=5s


### PR DESCRIPTION
This change makes the smarthome server's port configurable via the `PORT` environment variable when using Docker Compose. It maintains backward compatibility by defaulting to port 3000.

Key changes:
- `docker-compose.yml`: Added `${PORT:-3000}` substitution and `SERVER_PORT` environment variable.
- `application.properties`: Replaced hardcoded `3000` with `${SERVER_PORT:3000}`.
- `Dockerfile`: Removed `EXPOSE 3000` as requested.
- `README.md`: Added a new 'Configuration' section and updated usage examples.

---
*PR created automatically by Jules for task [11988181145013646104](https://jules.google.com/task/11988181145013646104) started by @SaschaPros*